### PR TITLE
Feature/users/:id/mails/:inBoxId

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,12 @@
   "parserOptions": {
     "ecmaVersion": "latest"
   },
-  "rules": {}
+  "rules": {
+    "no-param-reassign": "off",
+    "import/prefer-default-export": "off",
+    "no-promise-executor-return": "off",
+    "import/order": "off",
+    "no-use-before-define": "off",
+    "no-unused-vars": "warn"
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .prettierrc.json
+.eslintcache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# branch="$(git rev-parse --abbrev-ref HEAD)"
+branch="$(git rev-parse --abbrev-ref HEAD)"
 
-# if [ "$branch" = "develop" ]; then
-#   echo "You can't commit directly to main branch"
-#   exit 1
-# fi
+if [ "$branch" = "develop" ]; then
+  echo "You can't commit directly to main branch"
+  exit 1
+fi
 
-# npx lint-staged
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# branch="$(git rev-parse --abbrev-ref HEAD)"
+branch="$(git rev-parse --abbrev-ref HEAD)"
 
-# if [ "$branch" = "develop" ]; then
-#   echo "You can't push directly to main branch"
-#   exit 1
-# fi
+if [ "$branch" = "develop" ]; then
+  echo "You can't push directly to main branch"
+  exit 1
+fi

--- a/app.js
+++ b/app.js
@@ -5,8 +5,7 @@ const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const cors = require("cors");
 
-const indexRouter = require("./routes/index");
-const usersRouter = require("./routes/users");
+const usersRouter = require("./routes/api/users");
 
 const app = express();
 
@@ -19,10 +18,9 @@ app.use(
   cors({
     origin: "*",
     credentials: true,
-  })
+  }),
 );
 
-app.use("/", indexRouter);
 app.use("/users", usersRouter);
 
 app.use(function (req, res, next) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,25 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/node": {
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
+      "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA=="
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -259,11 +278,24 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "requires": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -360,6 +392,23 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "bson": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
+      "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "bytes": {
@@ -637,6 +686,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -1134,6 +1188,11 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1352,6 +1411,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -1423,6 +1487,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1662,6 +1731,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "kareem": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.3.tgz",
+      "integrity": "sha512-uESCXM2KdtOQ8LOvKyTUXEeg0MkYp4wGglTIpGcYHvjJcS5sn2Wkfrfit8m4xSbaNDAw2KdI9elgkOxZbrFYbg=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -1921,6 +1995,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -1992,6 +2072,49 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mongodb": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
+      "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+      "requires": {
+        "bson": "^4.6.1",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.4.1",
+        "saslprep": "^1.0.3",
+        "socks": "^2.6.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.2.tgz",
+      "integrity": "sha512-mZUXF6nUzRWk5J3h41MsPv13ukWlH4jOMSk6astVeoZ1EbdTJyF5I3wxKkvqBAOoVtzLgyEYUvDjrGdcPlKjAw==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.2.0.tgz",
+      "integrity": "sha512-kimHjks1FC4HkqM4FVNWxtGor6wYelHgl6eJ6GJmmJvMCI4FNGLwFceSL6hs7dHLZJnxIyGVqQjT/XTXCbjzpA==",
+      "requires": {
+        "bson": "^4.2.2",
+        "kareem": "2.3.3",
+        "mongodb": "4.3.1",
+        "mpath": "0.8.4",
+        "mquery": "4.0.2",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "sift": "13.5.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -2002,6 +2125,34 @@
         "depd": "~1.1.2",
         "on-finished": "~2.3.0",
         "on-headers": "~1.0.1"
+      }
+    },
+    "mpath": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+    },
+    "mquery": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.2.tgz",
+      "integrity": "sha512-oAVF0Nil1mT3rxty6Zln4YiD6x6QsUWYz927jZzjMxOK2aqmhEz5JQ7xmrKK7xRFA2dwV+YaOpKU/S+vfNqKxA==",
+      "requires": {
+        "debug": "4.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ms": {
@@ -2333,8 +2484,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -2400,6 +2550,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -2495,6 +2650,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2580,6 +2744,11 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sift": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -2602,6 +2771,29 @@
           "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
           "dev": true
         }
+      }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
       }
     },
     "statuses": {
@@ -2739,6 +2931,14 @@
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
+      }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
       }
     },
     "tsconfig-paths": {
@@ -2890,6 +3090,20 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "axios": "^0.25.0",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
+    "mongoose": "^6.2.0",
     "morgan": "~1.9.1"
   },
   "devDependencies": {

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+const mailController = require("../controller/mailController");
+
+router.get("/:id/mails/:inBoxId", mailController.getMailList);
+
+router.post("/:id/mails/trash", mailController.postTrash);
+
+router.delete("/:id/mails/trash", mailController.deleteTrash);
+
+module.exports = router;

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -1,11 +1,15 @@
 const express = require("express");
 const router = express.Router();
-const mailController = require("../controller/mailController");
+const {
+  getMailList,
+  postTrash,
+  deleteTrash,
+} = require("../controller/mailController");
 
-router.get("/:id/mails/:inBoxId", mailController.getMailList);
+router.get("/:id/mails/:inBoxId", getMailList);
 
-router.post("/:id/mails/trash", mailController.postTrash);
+router.post("/:id/mails/trash", postTrash);
 
-router.delete("/:id/mails/trash", mailController.deleteTrash);
+router.delete("/:id/mails/trash", deleteTrash);
 
 module.exports = router;

--- a/routes/controller/mailController.js
+++ b/routes/controller/mailController.js
@@ -1,0 +1,59 @@
+const axios = require("axios");
+const { getMailBody } = require("../utils/getMailBody");
+
+const getMailList = async (req, res, next) => {
+  const { gapitAuthorization } = req.headers;
+  const { inBoxId } = req.params;
+
+  try {
+    const headers = { authorization: gapitAuthorization };
+    const mailListUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=${inBoxId}&maxResults=10`;
+    const response = await axios.get(mailListUrl, { headers });
+
+    const mailList = await Promise.all(
+      response.data.messages.map(async (message) => {
+        const id = message.id;
+        const getEachMailUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}`;
+        const mail = await axios.get(getEachMailUrl, { headers });
+
+        return mail.data;
+      }),
+    );
+
+    const incodedMailList = mailList.map((mail) => {
+      let from, date, subject;
+
+      mail.payload.headers.forEach((header) => {
+        header.name === "From" && (from = header.value);
+        header.name === "Date" && (date = header.value);
+        header.name === "Subject" && (subject = header.value);
+      });
+
+      const result = {
+        id: mail.id,
+        from,
+        date,
+        subject,
+        snippet: mail.snippet,
+        content: getMailBody(mail.payload),
+      };
+
+      return result;
+    });
+
+    return res.send(incodedMailList);
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
+};
+
+const postTrash = (req, res, next) => {};
+
+const deleteTrash = (req, res, next) => {};
+
+module.exports = {
+  getMailList,
+  postTrash,
+  deleteTrash,
+};

--- a/routes/controller/mailController.js
+++ b/routes/controller/mailController.js
@@ -7,8 +7,9 @@ const getMailList = async (req, res, next) => {
 
   try {
     const headers = { authorization: gapitAuthorization };
-    const mailListUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=${inBoxId}&maxResults=10`;
+    const mailListUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=${inBoxId}&maxResults=1`;
     const response = await axios.get(mailListUrl, { headers });
+    const nextPageToken = response.data.nextPageToken;
 
     const mailList = await Promise.all(
       response.data.messages.map(async (message) => {
@@ -29,7 +30,7 @@ const getMailList = async (req, res, next) => {
         header.name === "Subject" && (subject = header.value);
       });
 
-      const result = {
+      const incodedMail = {
         id: mail.id,
         from,
         date,
@@ -38,10 +39,15 @@ const getMailList = async (req, res, next) => {
         content: getMailBody(mail.payload),
       };
 
-      return result;
+      return incodedMail;
     });
 
-    return res.send(incodedMailList);
+    const result = {
+      result: incodedMailList,
+      nextPageToken,
+    };
+
+    return res.json(result);
   } catch (err) {
     console.error(err);
     next(err);

--- a/routes/controller/mailController.js
+++ b/routes/controller/mailController.js
@@ -7,7 +7,7 @@ const getMailList = async (req, res, next) => {
 
   try {
     const headers = { authorization: gapitAuthorization };
-    const mailListUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=${inBoxId}&maxResults=1`;
+    const mailListUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?labelIds=${inBoxId}&maxResults=10`;
     const response = await axios.get(mailListUrl, { headers });
     const nextPageToken = response.data.nextPageToken;
 
@@ -21,7 +21,7 @@ const getMailList = async (req, res, next) => {
       }),
     );
 
-    const incodedMailList = mailList.map((mail) => {
+    const decodedMailList = mailList.map((mail) => {
       let from, date, subject;
 
       mail.payload.headers.forEach((header) => {
@@ -30,7 +30,7 @@ const getMailList = async (req, res, next) => {
         header.name === "Subject" && (subject = header.value);
       });
 
-      const incodedMail = {
+      const decodedMail = {
         id: mail.id,
         from,
         date,
@@ -39,11 +39,11 @@ const getMailList = async (req, res, next) => {
         content: getMailBody(mail.payload),
       };
 
-      return incodedMail;
+      return decodedMail;
     });
 
     const result = {
-      result: incodedMailList,
+      result: decodedMailList,
       nextPageToken,
     };
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,8 +1,0 @@
-const express = require("express");
-const router = express.Router();
-
-router.get("/", function (req, res, next) {
-  res.send("Home");
-});
-
-module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,8 +1,0 @@
-const express = require("express");
-const router = express.Router();
-
-router.get("/", function (req, res, next) {
-  res.send("respond with a resource");
-});
-
-module.exports = router;

--- a/routes/utils/getMailBody.js
+++ b/routes/utils/getMailBody.js
@@ -1,0 +1,32 @@
+module.exports.getMailBody = function (message) {
+  let encodedBody = "";
+
+  if (typeof message.parts === "undefined") {
+    encodedBody = message.body.data;
+  } else {
+    encodedBody = getHTMLPart(message.parts);
+  }
+
+  encodedBody = encodedBody
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+    .replace(/\s/g, "");
+
+  const buff = Buffer.from(encodedBody, "base64").toString("utf8");
+
+  return buff;
+};
+
+function getHTMLPart(arr) {
+  for (let i = 0; i <= arr.length; i++) {
+    if (typeof arr[i].parts === "undefined") {
+      if (arr[i].mimeType === "text/html") {
+        return arr[i].body.data;
+      }
+    } else {
+      return getHTMLPart(arr[i].parts);
+    }
+  }
+
+  return "";
+}


### PR DESCRIPTION
# gmail API GET

## 노션 칸반 링크
​
- [/users/:id/mails GET - 이메일 리스트 불러오기](https://www.notion.so/vanillacoding/users-id-mails-GET-8aecb82627934d2984e28be7d14e7656)
​
## 카드에서 구현 혹은 해결하려는 내용
- 각각의 label(CATEGORY_PROMOTIONS, SPAM, TRASH)대로 이메일 리스트를 불러온다.
- 이메일의 본문을 디코딩하고 필요한 정보들을 가공해서 return한다.
- 이메일은 10개씩 불러오고 nextPageToken 과 함께 이메일 리스트들이 배열의 형태로 보내진다.

## 테스트 방법
### 요청
`curl --location --request GET 'http://localhost:3001/users/:id/mails/:inBoxId' \ 
--header 'Authorization: Bearer accessToken'`
### 결과
<img width="717" alt="스크린샷 2022-02-07 오후 3 50 33" src="https://user-images.githubusercontent.com/80485020/152739166-8128fce2-c47b-4898-8168-b5da4aae5e8d.png">


## 기타 사항
- 각각의 이메일은 10개씩 불러오도록 설정하였는데 이 부분에 대해 어떻게 생각하시나요?