### PR TITLE
feature: get user search result from DB with pagination

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -5,6 +5,8 @@ const User = require("../models/User");
 const handleLogin = async (req, res, next) => {
   const { name, email } = req.body;
 
+  console.log(req.cookies);
+
   try {
     let user = await User.findOne({ email });
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,6 +2,24 @@ const jwt = require("jsonwebtoken");
 const createError = require("http-errors");
 const User = require("../models/User");
 
+const getSearchResult = async (req, res, next) => {
+  const { page = 1, size = 10, keyword = "" } = req.query;
+  const query = keyword && new RegExp(keyword);
+  const limit = parseInt(size);
+  const skip = (page - 1) * size;
+
+  try {
+    const users = await User.find(query ? { email: query } : {})
+      .limit(limit)
+      .skip(skip);
+
+    res.json({ result: { page, size, users } });
+  } catch (error) {
+    console.error(error);
+    next(error);
+  }
+};
+
 const getUserInfo = async (req, res, next) => {
   const { id } = req.params;
 
@@ -139,6 +157,7 @@ const changeItemLocation = async (req, res, next) => {
 };
 
 module.exports = {
+  getSearchResult,
   getUserInfo,
   getGuestBook,
   addMessage,

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,6 +5,7 @@ const {
   deleteTrash,
 } = require("../controllers/mailController");
 const {
+  getSearchResult,
   getUserInfo,
   getGuestBook,
   addMessage,
@@ -13,6 +14,8 @@ const {
 } = require("../controllers/userController");
 
 const router = express.Router();
+
+router.get("/", getSearchResult);
 
 router.get("/:id", getUserInfo);
 


### PR DESCRIPTION
# /users GET - 유저 검색

## 노션 칸반 링크
​
- [/users GET - 유저 검색](https://www.notion.so/vanillacoding/a595c93791e440d78feaa34f9ba6b81b?v=b466274725384ef899a2bc8f94b4b4fa&p=92dbcf6bc67b40958bff3c3c9e1df04b)
​
## 카드에서 구현 혹은 해결하려는 내용
- 친구 리스트에서 친구 신청을 하기 위한 검색을 하게 되는데, 그 과정에서 서버에 요청하는 API입니다.
- 유저 검색이기 때문에 페이지네이션으로 구현하게 되었고 페이지, 사이즈, 키워드의 쿼리 스트링을 받아 결과를 반환합니다.
​
## 테스트 방법
- page=1&size=1&keyword=gmail

<img width="680" alt="image" src="https://user-images.githubusercontent.com/80205036/153189745-f46fa93c-6817-4451-b292-d8ad9a2fac2e.png">

- default (page=1&size=10)

<img width="680" alt="image" src="https://user-images.githubusercontent.com/80205036/153189808-dd7fa198-9c67-42f2-9d1f-61e45e90f458.png">

## 기타 사항
- 모델의 도큐먼트 전체를 가져올 수 도 있는 요청이므로 페이지네이션으로 구현해 보았습니다. 메일과 유저 검색 이외에도 적용 가능한 무거운 요청이 있을지 같이 생각해 보면 좋을 것 같습니다 :) 