### PR TITLE
feature: receive and send realtime guestbook update

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -1,6 +1,8 @@
 const EVENTS = {
   JOIN: "join",
   LEFT: "left",
+  OPEN_POSTBOX: "openPostBox",
+  READ_MESSAGES: "readMessage",
   GET_MESSAGES: "getMessage",
   SEND_MESSAGE: "sendMessage",
   DISCONNECT: "disconnect",

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -72,7 +72,7 @@ const addPendingFriendList = async (req, res, next) => {
             isChecked: false,
           },
         },
-      },
+      }
     ).setOptions({ runValidators: true });
 
     res.status(201).json({
@@ -264,8 +264,9 @@ const addMessage = async (req, res, next) => {
         }
 
         userEmail = decoded.email;
-      },
+      }
     );
+
     const user = await User.findOne({ email: userEmail }).exec();
     const name = user.name;
 
@@ -276,7 +277,7 @@ const addMessage = async (req, res, next) => {
           guestBook: { name, message, date: isoDateTime },
         },
       },
-      { new: true },
+      { new: true }
     );
 
     res.json({
@@ -338,7 +339,7 @@ const changeItemLocation = async (req, res, next) => {
     await User.findByIdAndUpdate(
       id,
       { $set: { "outItemBox.$[item].location": newLocation } },
-      { arrayFilters: [{ "item._id": itemId }] },
+      { arrayFilters: [{ "item._id": itemId }] }
     );
 
     res.json({

--- a/data/guestbook.js
+++ b/data/guestbook.js
@@ -6,12 +6,17 @@ class Guestbook {
   }
 
   async initGuestBook(townId) {
-    const user = await User.findById(townId);
-    this.messages = user.guestBook;
+    try {
+      const user = await User.findById(townId);
+      this.messages = user.guestBook;
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   add(message) {
     this.messages.push(message);
+    return this.messages;
   }
 }
 

--- a/data/town.js
+++ b/data/town.js
@@ -4,8 +4,16 @@ class Town {
     this.guestbook = guestbook;
   }
 
-  addGuestbook(message) {
-    this.guestbook.add(message);
+  async addGuestbook(townId, message) {
+    try {
+      if (!this.guestbook.messages.length) {
+        await this.guestbook.initGuestBook(townId);
+      }
+
+      return this.guestbook.add(message);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   addVisitor(target) {
@@ -14,16 +22,11 @@ class Town {
   }
 
   removeVisitor(target) {
-    this.visitor.leave(target);
+    return this.visitor.leave(target);
   }
 
   getVisitors() {
     return this.visitor.visitors;
-  }
-
-  async getGuestbook(townId) {
-    await this.guestbook.initGuestBook(townId);
-    return this.guestbook.messages;
   }
 }
 

--- a/data/visitor.js
+++ b/data/visitor.js
@@ -8,9 +8,12 @@ class Visitor {
   }
 
   leave(target) {
-    this.visitors = this.visitors.filter(
+    const updatedVisitors = this.visitors.filter(
       (visitor) => visitor.email !== target.email
     );
+
+    this.visitors = updatedVisitors;
+    return updatedVisitors;
   }
 
   findDuplicate(target) {


### PR DESCRIPTION
# feature: receive and send realtime guestbook upddate

## 노션 칸반 링크

- [[socket][Backend]감지된 새 방명록 등록 이벤트로 변경된 새 방명록 배열 프론트로 보내기](https://www.notion.so/vanillacoding/a595c93791e440d78feaa34f9ba6b81b?v=b466274725384ef899a2bc8f94b4b4fa&p=8a6fd66992f64a62bc77aefb23e4c5aa)

## 카드에서 구현 혹은 해결하려는 내용
- "sendMessage" 이벤트 감지 후 해당 마을의 업데이트된 메시지 배열을 emit "getMessage" 

## 테스트 방법
- 구글, 사파리 브라우저로 각각 다른 아이디로 접속
- 제 3 유저의 마을에 방문하여 방명록이 실시간으로 업데이트 되는지 확인하였습니다.
